### PR TITLE
Set curl to follow redirect when downloading the uv4l_repo lpkey

### DIFF
--- a/installation.sh
+++ b/installation.sh
@@ -82,7 +82,7 @@ chmod 664 /home/pi/RaspberryIPCamera/secret/RaspberryIPCamera.secret
 # Install all UV4L components
 ########################################################################################
 # Add the supplier's repository key to our key database
-curl http://www.linux-projects.org/listing/uv4l_repo/lpkey.asc | sudo apt-key add -
+curl --location http://www.linux-projects.org/listing/uv4l_repo/lpkey.asc | sudo apt-key add -
 # Open /etc/apt/sources.list in Nano
 sudo nano /etc/apt/sources.list
 # PASTE INTO /etc/apt/sources.list below second line, then save and exit


### PR DESCRIPTION
The url for uv4l_repo lpkey has been changed, and a permanent redirect was put in place. With the `--location` argument, curl will follow the redirect and download the file intended.
```
$ curl -v http://www.linux-projects.org/listing/uv4l_repo/lpkey.asc
*   Trying 89.46.110.45...
* TCP_NODELAY set
* Expire in 200 ms for 4 (transfer 0x1ee28a0)
* Connected to www.linux-projects.org (89.46.110.45) port 80 (#0)
> GET /listing/uv4l_repo/lpkey.asc HTTP/1.1
> Host: www.linux-projects.org
> User-Agent: curl/7.64.0
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Server: aruba-proxy
< Date: Mon, 28 Dec 2020 22:23:19 GMT
< Content-Type: text/html
< Content-Length: 168
< Connection: keep-alive
< Location: https://www.linux-projects.org/listing/uv4l_repo/lpkey.asc
< X-ServerName: ipvsproxy221.ad.aruba.it
<
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>aruba-proxy</center>
</body>
</html>
* Connection #0 to host www.linux-projects.org left intact
```